### PR TITLE
Add recall evidence metadata tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Then just ask your agent things like *"search my past sessions for how we wired 
 | Tool | What it does |
 |---|---|
 | `recall(query, limit?)` | **Start here.** Best matching past-session turns **and** memory snippets across every tool. |
+| `recall_evidence(query, limit?)` | JSON recall results with source type, timestamp, session/file refs, snippets, and verification paths before relying on old context. |
 | `search_sessions(query, source?, project?, role?, since_days?, limit?)` | Full-text search over all session transcripts. Filter by tool, project path, role, or recency. |
 | `search_memory(query, source?, limit?)` | Search `CLAUDE.md` / `AGENTS.md` / `memory/*.md` across tools. |
 | `list_sessions(source?, project?, limit?)` | Recent sessions (newest first) with tool, project, time, turn count. |

--- a/reference_mcp/server.py
+++ b/reference_mcp/server.py
@@ -7,6 +7,7 @@ Tools return human-readable text because the consumer is an LLM agent.
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 
 from mcp.server.fastmcp import FastMCP
@@ -23,6 +24,42 @@ def _since(since_days: int | None) -> datetime | None:
 
 def _fmt_ts(ts: datetime | None) -> str:
     return ts.strftime("%Y-%m-%d %H:%M") if ts else "unknown-time"
+
+
+def _iso_ts(ts: datetime | None) -> str | None:
+    return ts.isoformat() if ts else None
+
+
+def _message_evidence(hit: search.Hit, query: str) -> dict:
+    m = hit.message
+    return {
+        "kind": "session_turn",
+        "score": round(hit.score, 4),
+        "source": m.source,
+        "role": m.role,
+        "timestamp": _iso_ts(m.ts),
+        "project": m.project or None,
+        "session_id": m.session_id,
+        "path": m.path,
+        "uuid": m.uuid or None,
+        "snippet": search.snippet(m.text, query),
+        "verification_path": {
+            "tool": "get_session",
+            "session_ref": m.session_id or m.path,
+            "source_path": m.path,
+        },
+    }
+
+
+def _memory_evidence(hit: search.MemoryHit) -> dict:
+    return {
+        "kind": "memory_file",
+        "score": hit.score,
+        "source": hit.source,
+        "path": hit.path,
+        "snippet": hit.snippet,
+        "verification_path": {"tool": "search_memory", "source_path": hit.path},
+    }
 
 
 def build_server() -> FastMCP:
@@ -94,6 +131,25 @@ def build_server() -> FastMCP:
                     f"  {search.snippet(m.text, query)}"
                 )
         return "\n".join(out) if out else f"Nothing found for {query!r}."
+
+    @mcp.tool()
+    def recall_evidence(query: str, limit: int = 8) -> str:
+        """Combined recall with machine-readable evidence metadata.
+
+        Use this before relying on an old-session or memory hit as current truth.
+        The response keeps the same search coverage as recall(), but returns JSON
+        with source type, timestamp/freshness, session/file refs, snippets, and a
+        verification path so agents can inspect the source before acting.
+        """
+        sess = search.get_index().search(query, limit=limit)
+        mem = search.search_memory(query, limit=max(3, limit // 2))
+        payload = {
+            "query": query,
+            "result_count": len(mem) + len(sess),
+            "memory": [_memory_evidence(h) for h in mem],
+            "sessions": [_message_evidence(h, query) for h in sess],
+        }
+        return json.dumps(payload, ensure_ascii=False, indent=2)
 
     @mcp.tool()
     def list_sessions(source: str | None = None, project: str | None = None, limit: int = 20) -> str:

--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -3,7 +3,8 @@
 from pathlib import Path
 
 from reference_mcp import normalize
-from reference_mcp.search import Index, tokens
+from reference_mcp.search import Hit, Index, MemoryHit, tokens
+from reference_mcp.server import _memory_evidence, _message_evidence
 
 FIX = Path(__file__).parent / "fixtures"
 
@@ -49,3 +50,33 @@ def test_cross_tool_search():
 def test_tokens_drop_stopwords():
     assert "the" not in tokens("the gemini grounding")
     assert "gemini" in tokens("the gemini grounding")
+
+
+def test_message_evidence_has_verification_path():
+    msgs = list(normalize.parse_claude(str(FIX / "claude_sample.jsonl")))
+    hit = Hit(msgs[0], 1.23456)
+
+    ev = _message_evidence(hit, "pg necessity")
+
+    assert ev["kind"] == "session_turn"
+    assert ev["source"] == "claude"
+    assert ev["role"] == "user"
+    assert ev["session_id"] == msgs[0].session_id
+    assert ev["path"] == msgs[0].path
+    assert ev["score"] == 1.2346
+    assert ev["verification_path"]["tool"] == "get_session"
+
+
+def test_memory_evidence_has_source_path():
+    hit = MemoryHit(source="claude", path="/tmp/CLAUDE.md", score=3, snippet="Use Postgres, not SQLite")
+
+    ev = _memory_evidence(hit)
+
+    assert ev == {
+        "kind": "memory_file",
+        "score": 3,
+        "source": "claude",
+        "path": "/tmp/CLAUDE.md",
+        "snippet": "Use Postgres, not SQLite",
+        "verification_path": {"tool": "search_memory", "source_path": "/tmp/CLAUDE.md"},
+    }


### PR DESCRIPTION
Adds a small machine-readable companion to recall(): `recall_evidence(query, limit?)`.\n\nWhy:\n- `recall()` is great for prose, but agents need source/freshness refs before treating old session hits as current truth.\n- This keeps the existing prose tool unchanged and adds an opt-in JSON result with memory/session result type, timestamp, session/file refs, snippet, score, and verification path.\n\nIncluded:\n- new MCP tool `recall_evidence`\n- helpers for session-turn and memory-file evidence envelopes\n- README tool table entry\n- tests for evidence helper shape\n\nValidation:\n- `python3 -m compileall reference_mcp`\n- `git diff --check`\n- direct helper smoke with a stubbed FastMCP import\n\nNote: I could not run pytest locally in this runner because uv/pip/pytest/python3-venv are unavailable.