### PR TITLE
Rename recall_evidence -> recall_with_sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Then just ask your agent things like *"search my past sessions for how we wired 
 | Tool | What it does |
 |---|---|
 | `recall(query, limit?)` | **Start here.** Best matching past-session turns **and** memory snippets across every tool. |
-| `recall_evidence(query, limit?)` | JSON recall results with source type, timestamp, session/file refs, snippets, and verification paths before relying on old context. |
+| `recall_with_sources(query, limit?)` | JSON recall results with source type, timestamp, session/file refs, snippets, and verification paths before relying on old context. |
 | `search_sessions(query, source?, project?, role?, since_days?, limit?)` | Full-text search over all session transcripts. Filter by tool, project path, role, or recency. |
 | `search_memory(query, source?, limit?)` | Search `CLAUDE.md` / `AGENTS.md` / `memory/*.md` across tools. |
 | `list_sessions(source?, project?, limit?)` | Recent sessions (newest first) with tool, project, time, turn count. |

--- a/reference_mcp/server.py
+++ b/reference_mcp/server.py
@@ -133,7 +133,7 @@ def build_server() -> FastMCP:
         return "\n".join(out) if out else f"Nothing found for {query!r}."
 
     @mcp.tool()
-    def recall_evidence(query: str, limit: int = 8) -> str:
+    def recall_with_sources(query: str, limit: int = 8) -> str:
         """Combined recall with machine-readable evidence metadata.
 
         Use this before relying on an old-session or memory hit as current truth.


### PR DESCRIPTION
Small rename for clarity. The tool returns each recall hit **with its sources** (source tool, timestamp/freshness, session/file ref, verification path), so `recall_with_sources` says what you get better than `recall_evidence`. Docstring and behavior unchanged.